### PR TITLE
Make no file found be a 404 instead of 500

### DIFF
--- a/iotappstory_PHP_FILE/iotappstoryv20.php
+++ b/iotappstory_PHP_FILE/iotappstoryv20.php
@@ -48,7 +48,7 @@ $db = array(
 );
 
 if(!isset($db[$_SERVER['HTTP_X_ESP8266_STA_MAC']])) {
-    header($_SERVER["SERVER_PROTOCOL"].' 500 ESP MAC not configured for updates', true, 500);
+    header($_SERVER["SERVER_PROTOCOL"].' 404 ESP MAC not configured for update, no .bin file associated with that mac address.', true, 404);
 }
 
 $localBinary = "./bin/".$db[$_SERVER['HTTP_X_ESP8266_STA_MAC']].".bin";
@@ -62,5 +62,3 @@ if((!check_header('HTTP_X_ESP8266_SDK_VERSION') && $db[$_SERVER['HTTP_X_ESP8266_
 } else {
     header($_SERVER["SERVER_PROTOCOL"].' 304 Not Modified', true, 304);
 }
-
-//header($_SERVER["SERVER_PROTOCOL"].' 500 no version for ESP MAC', true, 500);


### PR DESCRIPTION
On the serial output it just says "wrong HTTP code" where giving a 404 would at least show that there is no file found for the esp